### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module.exports = {
         loaders: [
             {
                 test: /\.font.(js|json)$/,
-                loader: "style!css!fontgen?formats=woff,eot,ttf"
+                loader: "style!css!fontgen?types=woff,eot,ttf"
             }
         ]
     }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You also can use a module like `glob` to pick up a variable set of icons, too. M
 # Configuration
 ## Loader parameters
 
-- `formats`, Array
+- `types`, Array
 Possible values are: `["svg", "eot", "wof", "ttf"]`.
 
 - `template`, String

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ module.exports = function() {
 
     // With everything set up, let's make an ACTUAL config.
     var formats = params.types || ['eot', 'woff', 'ttf', 'svg'];
+    if(formats.constructor !== Array) formats = [formats];
+
     var fontconf = {
         files: config.files,
         fontName: config.fontName,


### PR DESCRIPTION
Small fixes to documentation and code:

allow generating only one font format
if ?types=woff is used then params.types is a String instead of an Array