### PR TITLE
Correct way of finding absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function() {
     config.__dirname = path.dirname(this.resourcePath);
 
     var relativate = function(file) {
-        if(file.substr(0,1) == "/") {
+        if(path.resolve(file) === path.normalize(file)){
             // Absolute path.
             return file;
         } else {


### PR DESCRIPTION
Node on windows was not correctly identifying an absolute path.