### PR TITLE
Support cssTemplate in font.js/json config

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ module.exports = function() {
         dest: "",
         writeFiles: false
     };
+    
+    if(config.cssTemplate) {
+        fontconf.cssTemplate = config.cssTemplate;
+    }
 
     // svgicons2svgfont stuff
     var keys = [

--- a/index.js
+++ b/index.js
@@ -55,9 +55,15 @@ module.exports = function() {
         dest: "",
         writeFiles: false
     };
-    
+
     if(config.cssTemplate) {
         fontconf.cssTemplate = relativate(config.cssTemplate);
+    }
+
+    for(option in config.templateOptions) {
+        if( config.templateOptions.hasOwnProperty(option) ) {
+            fontconf.templateOptions[option] = config.templateOptions[option];
+        }
     }
 
     // svgicons2svgfont stuff

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function() {
     };
     
     if(config.cssTemplate) {
-        fontconf.cssTemplate = config.cssTemplate;
+        fontconf.cssTemplate = relativate(config.cssTemplate);
     }
 
     // svgicons2svgfont stuff


### PR DESCRIPTION
I needed to use a completely custom css template, this was a handy way to do it.