### PR TITLE
Fix url on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function() {
                         content: res[format]
                     }
                 );
-                urls[format] = path.join(pub, url);
+                urls[format] = path.join(pub, url).replace(/\\/g, '/');
                 self.emitFile(url, res[format]);
             } else {
                 urls[format] = 'data:'


### PR DESCRIPTION
On Windows retrieving of font is broken with error 
`
ERROR in ../~/css-loader!..!./octicons.font.js
Module not found: Error: Cannot resolve 'file' or 'directory' ./󀖋d36da36585f5d8fdec59ef75daf-Octicons.eot in c:\www\projects\fontgen-loader\test
 @ ../~/css-loader!..!./octicons.font.js 6:89-144
`
Path join creates path with backslash, when url shoul be with slash