### PR TITLE
Allow empty classPrefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ module.exports = function (content) {
         fontHeight: config.fontHeight || 1000, // Fixes conversion issues with small svgs
         templateOptions: {
             baseClass: config.baseClass || "icon",
-            classPrefix: config.classPrefix || "icon-"
+            classPrefix: "classPrefix" in config ? config.classPrefix : "icon-"
         },
         rename: (typeof config.rename == "function" ? config.rename : function (f) {
             return path.basename(f, ".svg");


### PR DESCRIPTION
This commit adds ability to generate icon classes without any prefixes (useful for css-modules).