### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ What a mess! Okay okay, so what do we do? We make our own. And how? ...good ques
 ## How `fontgen-loader` works.
 There is a tool that lets us generate fonts automaticaly by a configuration. The font is created by putting several SVG icons together and generating the proper file(s). That includes:
 
-- A font file for WOF, EOT, TTF and WOFF2. Also SVG, if you want. But there is a trend of removal withinb rowsers - you can see more on [caniuse](http://caniuse.com).
+- A font file for WOF, EOT, TTF and WOFF2. Also SVG, if you want. But there is a trend of removal within browsers - you can see more on [caniuse](http://caniuse.com).
 - A CSS has your font configured. That means, it's a proper `@font-face` declaration inclusive icon classes.
 - If you want, a HTML demo page.
 
@@ -20,7 +20,7 @@ module.exports = {
     resolve: {
         loaders: [
             {
-                test: /\.font.(js|json)$/,
+                test: /\.font\.(js|json)$/,
                 loader: "style!css!fontgen"
             }
         ]
@@ -88,7 +88,7 @@ You also can use a module like `glob` to pick up a variable set of icons, too. M
 ## Loader parameters
 
 - `template`, String
-Which template to use? By default, a CSS one is used. The template is to be processed by Handlebars. See [the generator](https://github.com/nfroidure/svgicons2svgfont)'s readme itself for more info.
+Which template to use? By default, a CSS one is used. The template is to be processed by Handlebars. See [the generator](https://github.com/sunflowerdeath/webfonts-generator)'s readme itself for more info.
 
 - `embed`, Boolean
 Should the fonts be embedded in the CSS? By default the fonts are written to disk. If `embed` is specified the font is base64 encoded and embedded inside the `@font-face` declaration. Example configuration: `loader: "style!css!fontgen?embed&types=woff"`.


### PR DESCRIPTION
Fixes:
* “withinb rowsers”
* Missing ```\``` before dot in ```/\.font.(js|json)$/```
* Link in “the generator” (template stuff is handled by webfonts-generator, not svgicons2svgfont)