### PR TITLE
Add codepoints options

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = function (content) {
         types: formats,
         order: formats,
         fontHeight: config.fontHeight || 1000, // Fixes conversion issues with small svgs
+        codepoints: config.codepoints,
         templateOptions: {
             baseClass: config.baseClass || "icon",
             classPrefix: "classPrefix" in config ? config.classPrefix : "icon-"


### PR DESCRIPTION
Passes codepoints option to set specific codes to icons 
For example : 
"codepoints": {
    "drop_down_arrow": 0xE001,
  },
